### PR TITLE
Sprint 1 - CI Pipeline Foundation Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        submodules: recursive
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -28,11 +26,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -e ./common-utils/
     
     - name: Run tests
       run: |
-        pytest tests/ -v
+        PYTHONPATH=. pytest -k test_analyzer --cov=analyzer --cov-report=term-missing:skip-covered --cov-fail-under=85 -v
         
     - name: Run agent-specific checks
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "common-utils"]
-	path = common-utils
-	url = git@github.com:pa5tabear/SpiceflowNavigator-CommonUtils.git

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ test:
 	pytest tests/ -v
 
 install:
-	pip install -r requirements.txt
-	pip install -e ./common-utils/
+        pip install -r requirements.txt
 
 dev:
 	python -c "from analyzer import StrategicAnalyzer; print('Strategy agent ready')"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 ## Quick Start
 
 ```bash
-# Clone with submodules (for agents)
-git clone --recursive git@github.com:pa5tabear/SpiceflowNavigator-Strategy.git
+git clone git@github.com:pa5tabear/SpiceflowNavigator-Strategy.git
 cd SpiceflowNavigator-Strategy
 
 # Install dependencies
@@ -34,17 +33,6 @@ make clean         # Clean temporary files
 ```
 
 
-## CommonUtils Submodule
-
-This repository includes CommonUtils as a submodule:
-
-```bash
-# Update CommonUtils to latest
-git submodule update --remote common-utils
-
-# Install CommonUtils in development mode
-pip install -e ./common-utils/
-```
 
 ## Related Repositories
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-# Navigator Strategy Agent Package 
+# Navigator Strategy Agent Package

--- a/analyzer.py
+++ b/analyzer.py
@@ -36,4 +36,3 @@ class StrategicAnalyzer:
             picked = sentences[:1]
         summary = " ".join(picked)
         return shorten(summary, width=max_words * 6, placeholder="...")
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,4 @@ sentence-transformers>=2.2.0
 scikit-learn>=1.3.0
 numpy>=1.24.0
 pydantic>=2.0.0
-pytest>=7.4.0 
-# CommonUtils provided via submodule in ./common-utils/
-# To install: pip install -e ./common-utils/
+pytest>=7.4.0

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,17 @@
+from analyzer import StrategicAnalyzer
+
+
+def test_keywords_summary():
+    transcript = (
+        "Our growth strategy is strong. We will cut costs. Competition is fierce."
+    )
+    analyzer = StrategicAnalyzer()
+    result = analyzer.analyze(transcript, max_words=20)
+    assert result == "Our growth strategy is strong. Competition is fierce."
+
+
+def test_no_keyword_fallback():
+    transcript = "Hello world. Nothing about business here."
+    analyzer = StrategicAnalyzer()
+    result = analyzer.analyze(transcript, max_words=10)
+    assert result == "Hello world."


### PR DESCRIPTION
## Summary
- drop `common-utils` submodule
- remove submodule install steps from CI workflow
- clean requirements and docs
- add initial analyzer tests

## Testing
- `PYTHONPATH=. pytest -k test_analyzer --cov=analyzer --cov-report=term-missing:skip-covered --cov-fail-under=85 -v`
- `ruff format --check .`
- `ruff check .`
- `scripts/ci/check_loc_budget.sh 30` *(fails: No such file or directory)*
- `scripts/ci/check_new_deps.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68478a3626488327884eec8217776e1e