### PR TITLE
feat(s4): implement analytics dashboard & reports

### DIFF
--- a/analytics/aggregation.py
+++ b/analytics/aggregation.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Dict, List, Any
+
+from insight_extractor import extract_insights
+from goal_model import Goal
+
+
+@dataclass
+class AggregationResult:
+    category_counts: Dict[str, int]
+    goal_scores: Dict[str, float]
+    trend: List[tuple[str, int]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "category_counts": dict(self.category_counts),
+            "goal_scores": dict(self.goal_scores),
+            "trend": list(self.trend),
+        }
+
+
+def aggregate_transcripts(
+    transcripts: List[Dict[str, Any]],
+    goals: Iterable[Goal],
+    start: datetime | None = None,
+    end: datetime | None = None,
+    category: str | None = None,
+    relevance: float = 0.0,
+) -> AggregationResult:
+    """Aggregate insights from transcripts by category and goal relevance."""
+
+    cat_counts: Counter[str] = Counter()
+    goal_scores: defaultdict[str, float] = defaultdict(float)
+    trend_counts: defaultdict[str, int] = defaultdict(int)
+
+    for item in transcripts:
+        text = item["text"]
+        ts: datetime = item.get("timestamp") or datetime.utcnow()
+        if start and ts < start:
+            continue
+        if end and ts > end:
+            continue
+
+        insights = extract_insights(text)
+        for ins in insights:
+            if category and ins["category"] != category:
+                continue
+            score = sum(g.score_content(ins["text"]) for g in goals)
+            if score < relevance:
+                continue
+            cat_counts[ins["category"]] += 1
+            period = ts.strftime("%Y-%m")
+            trend_counts[period] += 1
+
+        for g in goals:
+            goal_scores[g.name] += g.score_content(text)
+
+    trend = sorted(trend_counts.items())
+    return AggregationResult(cat_counts, dict(goal_scores), trend)

--- a/analytics/dashboard.py
+++ b/analytics/dashboard.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import List, Dict, Any
+
+
+@dataclass
+class ChartData:
+    """Represents chart series for dashboard visualization."""
+
+    title: str
+    series: List[tuple[str, float]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Metric:
+    name: str
+    value: float
+    unit: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RankedList:
+    title: str
+    items: List[tuple[str, float]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"title": self.title, "items": self.items}
+
+
+@dataclass
+class Dashboard:
+    charts: List[ChartData]
+    metrics: List[Metric]
+    rankings: List[RankedList]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "charts": [c.to_dict() for c in self.charts],
+            "metrics": [m.to_dict() for m in self.metrics],
+            "rankings": [r.to_dict() for r in self.rankings],
+        }

--- a/analytics/reports.py
+++ b/analytics/reports.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any
+
+from goal_model import Goal
+
+
+def generate_report(
+    aggregation: Dict[str, Any],
+    goals: Iterable[Goal],
+    format: str = "markdown",
+) -> str | Dict[str, Any]:
+    """Generate an executive summary report from aggregated insights."""
+
+    cat_counts = aggregation.get("category_counts", {})
+    goal_scores = aggregation.get("goal_scores", {})
+
+    total_insights = sum(cat_counts.values())
+    summary_lines = [f"Total insights: {total_insights}"]
+    for name, count in cat_counts.items():
+        summary_lines.append(f"{name}: {count}")
+
+    recommendations = []
+    for g in goals:
+        if goal_scores.get(g.name, 0) > 0:
+            recommendations.append(f"Focus on {g.name.lower()} opportunities")
+
+    if format == "markdown":
+        lines = ["# Executive Summary", ""]
+        lines.extend(f"- {line}" for line in summary_lines)
+        if recommendations:
+            lines.append("\n## Recommendations")
+            lines.extend(f"- {r}" for r in recommendations)
+        return "\n".join(lines)
+
+    return {"summary": summary_lines, "recommendations": recommendations}

--- a/tests/test_analytics_aggregation.py
+++ b/tests/test_analytics_aggregation.py
@@ -1,0 +1,44 @@
+import datetime
+
+from analytics.aggregation import aggregate_transcripts
+from goal_model import SOLAR_DEVELOPMENT, CARBON_REMOVAL
+
+
+def _sample_transcripts():
+    return [
+        {
+            "text": "We will reduce costs with automation to improve efficiency.",
+            "timestamp": datetime.datetime(2025, 6, 1),
+        },
+        {
+            "text": (
+                "We plan to monetize through new pricing models for our solar project "
+                "which will reach 120 MW."
+            ),
+            "timestamp": datetime.datetime(2025, 6, 2),
+        },
+        {
+            "text": "We plan to innovate with biochar to enable gigaton-scale carbon capture.",
+            "timestamp": datetime.datetime(2025, 6, 3),
+        },
+    ]
+
+
+def test_aggregation_basic():
+    trans = _sample_transcripts()
+    goals = [SOLAR_DEVELOPMENT, CARBON_REMOVAL]
+    result = aggregate_transcripts(trans, goals)
+    data = result.to_dict()
+    assert data["category_counts"]
+    assert data["goal_scores"][SOLAR_DEVELOPMENT.name] > 0
+    assert data["goal_scores"][CARBON_REMOVAL.name] > 0
+    assert data["trend"]
+
+
+def test_filtering():
+    trans = _sample_transcripts()
+    goals = [SOLAR_DEVELOPMENT, CARBON_REMOVAL]
+    start = datetime.datetime(2025, 6, 2)
+    result = aggregate_transcripts(trans, goals, start=start, category="Revenue Strategy")
+    data = result.to_dict()
+    assert len(data["trend"]) == 1

--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -1,0 +1,12 @@
+from analytics.dashboard import ChartData, Metric, RankedList, Dashboard
+
+
+def test_dashboard_export():
+    chart = ChartData(title="Insight Trend", series=[("2025-06", 3)])
+    metric = Metric(name="Total Insights", value=3, unit="count")
+    ranked = RankedList(title="Top Goals", items=[("Solar Development", 1.5)])
+    dash = Dashboard(charts=[chart], metrics=[metric], rankings=[ranked])
+    data = dash.to_dict()
+    assert data["charts"][0]["title"] == "Insight Trend"
+    assert data["metrics"][0]["name"] == "Total Insights"
+    assert data["rankings"][0]["items"][0][0] == "Solar Development"

--- a/tests/test_analytics_reports.py
+++ b/tests/test_analytics_reports.py
@@ -1,0 +1,17 @@
+from analytics.reports import generate_report
+from goal_model import SOLAR_DEVELOPMENT
+
+
+def test_report_generation():
+    aggregation = {
+        "category_counts": {"Revenue Strategy": 2},
+        "goal_scores": {SOLAR_DEVELOPMENT.name: 1.0},
+        "trend": [("2025-06", 2)],
+    }
+    report_md = generate_report(aggregation, [SOLAR_DEVELOPMENT], format="markdown")
+    assert "# Executive Summary" in report_md
+    assert "Revenue Strategy" in report_md
+
+    report_dict = generate_report(aggregation, [SOLAR_DEVELOPMENT], format="dict")
+    assert isinstance(report_dict, dict)
+    assert "recommendations" in report_dict


### PR DESCRIPTION
## Summary
- add analytics aggregation engine with filtering
- provide dashboard dataclasses for UI
- generate markdown reports from aggregated data
- test analytics aggregation, dashboard, and reports

## Testing
- `python -m pytest -k test_analytics -q`


------
https://chatgpt.com/codex/tasks/task_e_68479a7ddec8832791c4c398c53b3e2a